### PR TITLE
ci: add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.11
+    # This conforms to Go workspace requirements (we are pre-modules)
+    working_directory: /go/src/github.com/google/goterm
+
+    steps:
+      - checkout
+      - run:
+          name: Run unit tests
+          command: go test -v ./...


### PR DESCRIPTION
Hello @skalle,

as mentioned, this adds CircleCI support, with green build :-)

You can have a look at the current status of the build of my fork at https://circleci.com/gh/marco-m/goterm/4

To make this work, you need to create an account on https://circleci.com using your github credentials, go to "Add Projects", select your goterm repo and enable building.