### PR TITLE
ci: build also for Go 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,37 @@
+#
+# YAML anchor to keep configuration DRY.
+#
+common: &common
+  # This conforms to Go workspace requirements (we are pre-modules).
+  working_directory: /go/src/github.com/google/goterm
+  steps:
+    - checkout
+    - run:
+        name: Go version
+        command: go version
+    - run:
+        name: Run unit tests
+        command: go test -v ./...
+
+#
+# CircleCI.
+#
 version: 2
+
 jobs:
-  build:
+  go-1.11:
     docker:
       - image: circleci/golang:1.11
-    # This conforms to Go workspace requirements (we are pre-modules)
-    working_directory: /go/src/github.com/google/goterm
+    <<: *common
+  go-1.12:
+    docker:
+      - image: circleci/golang:1.12
+    <<: *common
 
-    steps:
-      - checkout
-      - run:
-          name: Run unit tests
-          command: go test -v ./...
+workflows:
+  version: 2
+  test:
+    # These will run in parallel.
+    jobs:
+      - go-1.11
+      - go-1.12


### PR DESCRIPTION
We now build for Go 1.11 and 1.12, in parallel.

For detailed explanations about the CircleCI UI, see the equivalent PR https://github.com/google/goexpect/pull/41